### PR TITLE
CRAYSAT-1568: Allow empty files to pass license check

### DIFF
--- a/license_check.py
+++ b/license_check.py
@@ -241,6 +241,8 @@ class LicenseCheck(object):
         file_type = file_type_def["type"]
         with open(filename) as f:
             content = f.read(4092)
+        if not content:
+            return self.LicenseCheckResult(0, "File %s is empty" % filename)
         logging.debug("Trying main file comment type for %s as %s" % (filename, file_type))
         pattern = self.license_pattern_by_type[file_type][0]
         logging.debug("Applying pattern:\n%s\nagainst content\n%s" % (pattern, content))

--- a/license_check_test.py
+++ b/license_check_test.py
@@ -23,6 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import unittest
+from unittest.mock import patch, mock_open
 import license_check
 import sys
 import logging
@@ -128,6 +129,14 @@ class LicenseCheckTest(unittest.TestCase):
         result = checker.check_file("tests/valid_old_range_inline.go")
         self.assertEqual(result.code, 0)
         self.assertRegex(result.message, "^License is up to date:")
+
+    def testEmptyFile(self):
+        """Test that an empty file passes the license check."""
+        checker = license_check.LicenseCheck()
+        with patch('builtins.open', mock_open(read_data='')):
+            result = checker.check_file("tests/empty_file.py")
+        self.assertEqual(result.code, 0)
+        self.assertRegex(result.message, "^File tests/empty_file.py is empty")
 
     # [2020] > 2020-2021
     def testConvertSingleYearToRangeJava(self):
@@ -320,6 +329,7 @@ class LicenseCheckTest(unittest.TestCase):
         os.rmdir(tempdir)
 
 
-logging.basicConfig(level=logging.ERROR)
-os.chdir(sys.path[0])
-unittest.main()
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.ERROR)
+    os.chdir(sys.path[0])
+    unittest.main()


### PR DESCRIPTION
This commit changes the license check so that empty files are always allowed by the license checker. This commit also adds a unit test for this behavior.

Add `if __name__ == '__main__'` guard around main code in the test script, so that unit tests can be discovered and run with a test runner.

## Summary and Scope

* Resolves [CRAYSAT-1568](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1568)
* Slack discussion: https://cray.slack.com/archives/C01JRKK8J2F/p1652822599883229

## Testing

### Tested on:

* Unit Test

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

