### PR TITLE
CASMINST-7278 Prepare license-check for org workflow usage

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,20 +29,8 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
-
-    container:
-      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      credentials:
-          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v46
-
-    - name: License Check
-      if: ${{ steps.changed-files.outputs.all_changed_files }}
-      run: /usr/local/bin/python3 /license_check/license_check.py ${{ steps.changed-files.outputs.all_changed_files }}
+      - uses: Cray-HPE/license-checker@v2


### PR DESCRIPTION
## Summary and Scope

Update / add bindings in license-check repo required for organization level enforcement.

## Issues and Related PRs

* Resolves [CASMINST-7278](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7278)

## Testing
### Tested on:

Enforcement of license check on this PR provides a test.